### PR TITLE
ISSUE-11 Adding gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,23 @@
 # Project exclude paths
 /.gradle/
+build/
+
+# Local configuration file (sdk path, etc)
+local.properties
+
+# Auto Generated workspace
+.idea/
+
+# Android Studio generated files and folders
+captures/
+.externalNativeBuild/
+.cxx/
+*.apk
+output.json
+
+# Keystore files
+*.jks
+*.keystore
+
+# Android Profiling
+*.hprof


### PR DESCRIPTION
Link to issue: https://github.com/priyank1968/CloverEmployeeAppointment/issues/11

As it was encountered by team members the properties file kept on interfering with active development. Therefore adding a git ignore to ignore auto generated files from version control.